### PR TITLE
Fixes and updates for SplitDAE solver

### DIFF
--- a/src/NonLinearNewton.jl
+++ b/src/NonLinearNewton.jl
@@ -1,5 +1,7 @@
 module NonLinearNewton
 
+import Infiltrator
+
 import LinearAlgebra
 
 """
@@ -42,11 +44,11 @@ function solve(
     verbose >= 1 && @info "iters $iters Lnorm_2 $Lnorm_2 Lnorm_inf $Lnorm_inf u $u residual $residual"
     
     if (Lnorm_inf > reltol || iters < miniters)
-        jacobian = jac(u)
+        jacobianfac = jac(u)
         while (Lnorm_inf > reltol || iters < miniters) && iters < maxiters
             
-            verbose >= 4 && @info "iters $iters jac:" jacobian
-            u = u - jacobian \ residual
+            verbose >= 4 && @info "iters $iters jac:" jacobianfac
+            u = u - jacobianfac \ residual
             if u_min != -Inf
                 u = max.(u, u_min)
             end
@@ -56,7 +58,7 @@ function solve(
             Lnorm_inf = LinearAlgebra.norm(residual, Inf)
 
             if !jac_constant && Lnorm_inf > reltol
-                jacobian = jac(u)
+                jacobianfac = jac(u)
             end
             
             verbose >= 2 && @info "iters $iters Lnorm_2 $Lnorm_2 Lnorm_inf $Lnorm_inf"

--- a/src/PALEOmodel.jl
+++ b/src/PALEOmodel.jl
@@ -13,7 +13,7 @@ PB.value_ad(x::ForwardDiff.Dual) = ForwardDiff.value(x)
 abstract type AbstractOutputWriter
 end
 
-# include("Plot.jl")
+include("SparseUtils.jl")
 
 include("SolverView.jl")
 

--- a/src/SolverView.jl
+++ b/src/SolverView.jl
@@ -276,8 +276,12 @@ function create_solver_view(
                     exclude_var_nameroots=exclude_var_nameroots
                 )
 
-            append!(var_vec, vars)
-            if !isnothing(var_deriv_vec)
+            if isnothing(var_deriv_vec)
+                # sort by name: VF_Constraint and VF_State are unpaired in general, but in some cases will have a convenient ordering based on name
+                sort!(vars; by=v->PB.fullname(v))
+                append!(var_vec, vars)
+            else
+                append!(var_vec, vars)
                 append!(var_deriv_vec, vars_deriv)
             end
             if !isnothing(cr_vec)

--- a/src/SparseUtils.jl
+++ b/src/SparseUtils.jl
@@ -1,0 +1,236 @@
+"""
+    SparseUtils
+
+Contains convenience functions and optimised special cases for sparse matrices.
+"""
+module SparseUtils
+
+import SparseArrays
+import LinearAlgebra
+import Infiltrator
+
+"""
+    add_sparse_fixed!(A::SparseMatrixCSC, B::SparseMatrixCSC)
+    add_sparse_fixed!(A::SparseMatrixCSC, B::SparseMatrixCSC[iA, jA])
+
+Sparse matrix `A .+= B`, without modifying sparsity pattern of `A`.
+
+Errors if `B` contains elements not in sparsity pattern of `A`
+
+    julia> A = SparseArrays.sparse([1, 4], [2, 3], [1.0, 1.0], 4, 4)
+    julia> B = SparseArrays.sparse([1], [2], [2.0], 4, 4)
+    julia> SparseUtils.add_sparse_fixed!(A, B) # OK
+    julia> C = SparseArrays.sparse([2], [2], [2.0], 4, 4)
+    julia> SparseUtils.add_sparse_fixed!(A, C) # errors
+
+`B` can be a `view`, with the restriction that the first index subset `iA` must be a `UnitRange`, eg
+`B[2:3, 3:4]` or `B[2:3, [3, 4]]` is OK, `B[[2, 3], 3:4]` is not supported.
+"""
+function add_sparse_fixed!(A::SparseArrays.SparseMatrixCSC, B::SparseArrays.SparseMatrixCSC)
+    size(A) == size(B) || throw(DimensionMismatch("A and B are not the same size"))
+
+    @inbounds for j in 1:size(B, 2)
+        idx_A = A.colptr[j]
+        for idx_B in B.colptr[j]:(B.colptr[j+1]-1)
+            i_B = B.rowval[idx_B]
+            while idx_A < A.colptr[j+1] && A.rowval[idx_A] != i_B
+                idx_A += 1
+            end
+            idx_A < A.colptr[j+1] || error("element [$i_B, $j] in B is not present in A")
+            A.nzval[idx_A] += B.nzval[idx_B]
+        end
+    end
+    return A
+end
+
+function add_sparse_fixed!(A::SparseArrays.SparseMatrixCSC, B::SubArray{T, 2, <:SparseArrays.SparseMatrixCSC, <:Tuple{UnitRange, I2}, false}) where {T, I2}
+    return add_sparse_fixed!(A, B.parent, B.indices[1], B.indices[2])
+end
+
+# A .+= B[iB, jB]
+function add_sparse_fixed!(A::SparseArrays.SparseMatrixCSC, B::SparseArrays.SparseMatrixCSC, iB::UnitRange, jB)
+    size(A) == (length(iB), length(jB)) || throw(DimensionMismatch("A and B[iB, jB] are not the same size"))
+
+    @inbounds for (j_A, j_B) in zip(1:size(A, 2), jB)
+        idx_A = A.colptr[j_A]
+        for idx_B in B.colptr[j_B]:(B.colptr[j_B+1]-1)
+            i_B = B.rowval[idx_B]
+            if i_B in iB
+                while idx_A < A.colptr[j_A+1] && iB[A.rowval[idx_A]] != i_B
+                    idx_A += 1
+                end
+                idx_A < A.colptr[j_A+1] || error("element B[$i_B, $j_B] in B is not present in A")
+                A.nzval[idx_A] += B.nzval[idx_B]
+            end
+        end
+    end
+    return A
+end
+
+"""
+    get_column_sparse!(x::AbstractVector, A::SparseMatrixCSC[iA, jA::Int64]) -> num_nonzero::Int
+
+Get a Vector `x` from a column of sparse matrix `A`
+
+Calculates x .= A[iA, jA::Int] where `iA` is a range of indices and `jA` specifies column.
+
+Returns the number of non-zero elements in x
+"""
+function get_column_sparse!(x::AbstractVector, A::SubArray{T, 1, <:SparseArrays.SparseMatrixCSC, <:Tuple{I1, Int}, false}) where {T, I1}
+    return get_column_sparse!(x, parent(A), A.indices[1], A.indices[2])
+end
+
+function get_column_sparse!(x::AbstractVector, A::SparseArrays.SparseMatrixCSC, iA, jA::Int64)
+    length(x) == length(iA) || throw(DimensionMismatch("x and iA are not the same length"))
+    x .= 0.0
+
+    n_nonzero = 0
+    i = 1
+    @inbounds for idx_A in A.colptr[jA]:(A.colptr[jA+1]-1)
+        i_A = A.rowval[idx_A]
+        if i_A < first(iA)
+            continue
+        end
+        if i_A > last(iA)
+            break
+        end
+        i = _find_i(i, iA, i_A)
+        if i_A == iA[i]
+            x[i] = A.nzval[idx_A]
+            n_nonzero += 1
+        end
+    end
+    return n_nonzero
+end
+
+# find ivals[i] == iv, starting at i
+# returns i which may or may not be correct
+@inline function _find_i(i::Integer, ivals, iv)
+    @inbounds while iv > ivals[i] && i < length(ivals)
+        i += 1
+    end
+    return i
+end
+
+function check_all_zero(x::AbstractVector, ifrom, ito)
+    num_zeros = 0
+    @inbounds for i in ifrom:ito
+        num_zeros += !iszero(x[i])
+    end
+    num_zeros == 0 || error("x[$ifrom:$ito] != 0")
+    return nothing
+end
+
+"""
+    add_column_sparse_fixed!(A::SparseMatrixCSC[:, jA], y)
+
+Add a column y to A[:, jA], checking sparsity pattern
+"""
+function add_column_sparse_fixed!(A::SubArray{T, 1, <:SparseArrays.SparseMatrixCSC, <:Tuple{Base.Slice, Int}, false}, y::AbstractVector) where {T}
+    return add_column_sparse_fixed!(parent(A), A.indices[2], y)
+end
+
+function add_column_sparse_fixed!(A::SparseArrays.SparseMatrixCSC, jA::Int64, y::AbstractVector)
+    size(A, 1) == length(y) || throw(DimensionMismatch("size(A, 1) != length(y)"))
+
+    last_i = 1
+    @inbounds for idx_A in A.colptr[jA]:(A.colptr[jA+1]-1)
+        i = A.rowval[idx_A]
+        check_all_zero(y, last_i+1, i-1)
+        A.nzval[idx_A] += y[i]
+        last_i = i
+    end
+    check_all_zero(y, last_i+1, length(y))
+
+    # idx_A = A.colptr[jA]
+    # i_A = A.rowval[idx_A]
+    # @inbounds for (i_y, y) in zip(eachindex(y), y)
+    #     if !iszero(y)
+    #         while i_A != i_y && idx_A < A.colptr[jA+1]
+    #             idx_A +=1
+    #             i_A = A.rowval[idx_A]
+    #         end
+    #         i_A == i_y || error("element y[$i_y] in y is not present in A[:, $jA]")
+    #         A.nzval[idx_A] += y
+    #     end    
+    # end
+    
+    return A
+end
+
+"""
+    mult_sparse_vec!(y::AbstractVector, A::SparseMatrixCSC[iA, jA], x::AbstractVector)
+
+Calculate `y .= A[iA, jA] * x`, where `iA` and `jA` are index ranges defining a part of `A`
+"""
+function mult_sparse_vec!(y::AbstractVector, A::SubArray{T, 2, <:SparseArrays.SparseMatrixCSC, I, false}, x::AbstractVector) where {T, I}
+    return mult_sparse_vec!(y, parent(A), A.indices[1], A.indices[2], x)
+end
+
+function mult_sparse_vec!(y::AbstractVector, A::SparseArrays.SparseMatrixCSC, iA, jA, x::AbstractVector)
+    length(iA) == length(y) || throw(DimensionMismatch("length(iA) != length(y)"))
+    length(jA) == length(x) || throw(DimensionMismatch("length(jA) != length(x)"))
+
+    y .= 0.0
+
+    @inbounds for (j, j_A) in enumerate(jA)
+        i = 1
+        for idx_A in A.colptr[j_A]:(A.colptr[j_A+1]-1)
+            i_A = A.rowval[idx_A]
+            i = _find_i(i, iA, i_A)
+            if i_A == iA[i]
+                y[i] += A.nzval[idx_A]*x[j]
+            end
+            
+        end
+    end
+    return nothing
+end
+
+
+
+"""
+    get_sparse_inverse(A::AbstractMatrix) -> A_inv::SparseArrays.SparseMatrixCSC
+
+Horrible hack to get a sparse inverse via a dense inverse (very slow, allocates a huge dense matrix)
+
+Intended for use when calculating sparsity patterns only.
+Workaround for missing functions to calculate A \\ x for sparse x ie preserving sparsity.
+"""
+function get_sparse_inverse(A::AbstractMatrix)
+
+    # find dense inverse
+    A_inv_dense = LinearAlgebra.inv(Matrix(A))
+    # reconstruct a sparse matrix
+    ij = Tuple.(findall(!iszero, A_inv_dense))
+    I = [i for (i,j) in ij]
+    J = [j for (i,j) in ij]
+    V = [A_inv_dense[i, j] for (i, j) in ij]
+    A_inv = SparseArrays.sparse(I, J, V)
+
+    return A_inv
+end
+
+
+"fill structural non-zeros: return sparse matrix with all stored elements filled with `val`"
+function fill_sparse_jac(initial_jac; val=1.0, fill_diagonal=true)
+    num_elements = size(initial_jac, 1)*size(initial_jac, 2)
+
+    @info "  fill_sparse_jac: initial_jac nnz $(SparseArrays.nnz(initial_jac)) "*
+        "($(round(100*SparseArrays.nnz(initial_jac)/num_elements, sigdigits=3))%) non-zero $(count(!iszero, initial_jac))"
+    I, J, _ = SparseArrays.findnz(initial_jac)
+
+    jac_filled = SparseArrays.sparse(I, J, val, size(initial_jac, 1), size(initial_jac, 2) )
+    if fill_diagonal
+        size(initial_jac, 1) == size(initial_jac, 2) ||
+            error("fill_sparse_jac: fill_diagonal == true and Jacobian is not square")
+        for i = 1:size(initial_jac, 1)
+            jac_filled[i, i] = val
+        end
+        @info "  fill_sparse_jac: after filling diagonal nnz $(SparseArrays.nnz(jac_filled))"     
+    end
+
+    return jac_filled
+end
+
+end

--- a/src/SplitDAE.jl
+++ b/src/SplitDAE.jl
@@ -7,6 +7,7 @@ import PALEOmodel
 import LinearAlgebra
 import SparseArrays
 import ForwardDiff
+import SparseDiffTools
 import Infiltrator
 using Logging
 import StaticArrays
@@ -16,6 +17,7 @@ import ..SolverFunctions
 import ..ODE
 import ..JacobianAD
 import ..NonLinearNewton
+import ..SparseUtils
 
 """
     create_split_dae(
@@ -25,8 +27,9 @@ import ..NonLinearNewton
         jac_cellranges=modeldata.cellranges_all,
         operatorID_inner=0,
         transfer_inner_vars=["tmid", "volume", "ntotal", "Abox"],  # additional Variables needed by 'inner' Reactions
+        inner_jac_ad=:ForwardDiff: # form of automatic differentiation to use for Jacobian for inner solver (options `:ForwardDiff`, `:ForwardDiffSparse`)
         init_logger=Logging.NullLogger(),
-        inner_kwargs=(reltol=1e-9, miniters=1, maxiters=10, verbose=0),
+        inner_kwargs=(verbose=0, miniters=2, reltol=1e-12, jac_constant=true, u_min=1e-60),
     ) -> (ms::ModelSplitDAE, initial_state_outer, jac_outer_prototype)
 
 Given a model that contains both ODE variables and algebraic constraints, creates a callable struct `ms::`[`ModelSplitDAE`](@ref)
@@ -52,14 +55,27 @@ full model derivative that need to be copied before the Jacobian calculation or 
 function create_split_dae(
     model, initial_state, modeldata;
     tss_jac_sparsity,
-    request_adchunksize=10,
+    request_adchunksize=ForwardDiff.DEFAULT_CHUNK_THRESHOLD,
     jac_cellranges::Vector{<:PB.AbstractCellRange}=modeldata.cellranges_all,    
     operatorID_inner=0,
     transfer_inner_vars=["tmid", "volume", "ntotal", "Abox"],  # additional Variables needed by 'inner' Reactions
+    inner_jac_ad=:ForwardDiff,
     init_logger=Logging.NullLogger(),
-    inner_kwargs=(reltol=1e-9, miniters=1, maxiters=10, verbose=0),
+    inner_kwargs=(verbose=0, miniters=2, reltol=1e-12, jac_constant=true, u_min=1e-60),
 )
     PB.check_modeldata(model, modeldata)
+
+    # Notation:
+    #
+    # 'outer' Variables are PALEO stateexplicit, stateexplicit_deriv (paired ODE derivatives, with :vfunction=PB.VF_StateExplicit, PB.VF_Deriv)
+    # 'inner' Variables are PALEO state, constraint (DAE state and algebraic constraints, with :vfunction=PB.VF_StateExplicit, PB.VF_Deriv)
+    #
+    # There are three modeldata structs (with data arrays) here, with corresponding
+    # dispatchlists and variable aggregators:
+    #
+    # modeldata:            Float64 elements
+    # modeldata_jacfull:    Dual numbers needed for full Jacobian
+    # modeldata_jaccell:    Dual numbers needed for per-cell Jacobian
 
     sva = modeldata.solver_view_all
     # We only support explicit ODE + DAE constraints (no implicit variables)
@@ -71,129 +87,218 @@ function create_split_dae(
     # dispatchlists_recalc_deriv = nothing # disable
 
     # Variable aggegators for 'outer' ODE variables only
-    va_outer_state = sva.stateexplicit
-    va_outer_state_deriv = sva.stateexplicit_deriv
+    va_stateexplicit = sva.stateexplicit
+    va_stateexplicit_deriv = sva.stateexplicit_deriv
     # calculate initial_state_outer
     PALEOmodel.set_statevar!(sva, initial_state)
-    initial_state_outer = Vector{eltype(modeldata)}(undef, length(va_outer_state))
-    copyto!(initial_state_outer, va_outer_state)
+    initial_state_outer = Vector{eltype(modeldata)}(undef, length(va_stateexplicit))
+    copyto!(initial_state_outer, va_stateexplicit)
 
-    # full sparse jacobian jacode(Jfull, u, p, t) where Jfull has sparsity pattern jac_prototype
-    @info "split_dae:  using Jacobian :ForwardDiffSparse"
+    
+    # find all (state, constraint) algebraic constraints
+    io = IOBuffer()
+   
+    va_state = sva.state
+    va_constraints = sva.constraints
+    n_inner_solve = length(va_state.vars)
+    println(io, "create_split_dae:  $n_inner_solve algebraic state and constraint Variables for inner Newton solve:")
+    for (var, indices) in zip(va_state.vars, va_state.indices)
+        println(io, "        $(PB.fullname(var))  indices $indices")
+    end
+    for (var, indices) in zip(va_constraints.vars, va_constraints.indices)
+        println(io, "        $(PB.fullname(var))  indices $indices")
+    end
+    # find Domain for inner solve
+    inner_domains =unique([var.domain for var in va_state.vars])
+    length(inner_domains) == 1 || error("TODO only 1 Domain with algebraic constraints supported, Domains=$inner_domains")
+    inner_domain = inner_domains[1]
+    # find cellrange for inner Domain
+    cellrange_inner = PB.Grids.create_default_cellrange(inner_domain, inner_domain.grid, operatorID=operatorID_inner)
+    println(io, "    inner Newton solve Domain $inner_domain, cellrange $cellrange_inner")
+    @info String(take!(io))
+
+
+    ###########################################################
+    # construct function objects to calculate per-cell constraint Variables
+    ##################################
+    cellcellranges, cellderivs, cellstateidxfull, cellconstraintsidxfull, cellinitialstates = [], [], [], [], [], []
+    cellworksp = fill(NaN, n_inner_solve)
+   
+    for i in cellrange_inner.indices
+        # create a cellrange that refers to this one cell
+        cellrange = PB.CellRange(cellrange_inner.domain, cellrange_inner.operatorID, i)
+        push!(cellcellranges, cellrange)
+        
+        # VariableAggregator to calculate state and constraints for this cell
+        vars_cellranges = fill(cellrange, n_inner_solve)
+        va_cell_state = PB.VariableAggregator(va_state.vars, vars_cellranges, modeldata)
+        va_cell_constraints = PB.VariableAggregator(va_constraints.vars, vars_cellranges, modeldata)
+        # read out initial value for state variables
+        cell_initial_state = Vector{eltype(modeldata)}(undef, n_inner_solve)
+        copyto!(cell_initial_state, va_cell_state)
+        push!(cellinitialstates, cell_initial_state)
+        # dispatchlists for this cell
+        va_cell_dl = PB.create_dispatch_methodlists(model, modeldata, [cellrange])
+        push!(cellderivs, ModelDerivCell(n_inner_solve, modeldata, va_cell_state, va_cell_constraints, va_cell_dl, cellworksp))
+       
+        # index in full model for per-cell Variables
+        push!(cellstateidxfull, [indices[i] + length(va_stateexplicit) for indices in va_state.indices])
+        push!(cellconstraintsidxfull, [indices[i] + length(va_stateexplicit_deriv) for indices in va_constraints.indices])
+    end
+
+    ##########################################################################################    
+    # Get function object and sparsity pattern for full sparse jacobian 
+    # jacfull(Jfull, u, p, t) where Jfull has sparsity pattern jacfull_prototype
+    ###############################################################################
+
+    @info "create_split_dae:  creating full Jacobian using :ForwardDiffSparse"
     jacfull, jacfull_prototype = PALEOmodel.JacobianAD.jac_config_ode(
         :ForwardDiffSparse, model, initial_state, modeldata, tss_jac_sparsity,
         request_adchunksize=request_adchunksize,
-        jac_cellranges=jac_cellranges
+        jac_cellranges=jac_cellranges,
+        fill_jac_diagonal=false,
     )
-    @info "split_dae:  Variables to be copied from 'modeldata' before Jacobian calculation:"
+    @info "create_split_dae:  Variables to be copied from 'modeldata' before full Jacobian calculation:"
     # any Variables calculated by modelode but not jacode, that need to be copied
-    transfer_data_ad, transfer_data = PALEOmodel.JacobianAD.jac_transfer_variables(
+    transfer_data_jacfull, transfer_data = PALEOmodel.JacobianAD.jac_transfer_variables(
         model,
         jacfull.modeldata,
         modeldata
     )
 
+    #########################################################################################
+    # Calculate Jacobian sparsity patterns for outer and inner Jacobians from full Jacobian
+    #########################################################################################
     
-    # find all (state, constraint) algebraic constraints
-    vinner_names = []
-    vinner_indices = []
-    inner_domains = []
-    va_state = sva.state
-    va_constraints = sva.constraints
-    
-    io = IOBuffer()
-    println(io, "    algebraic constraint Variables for inner Newton solve:")
-    for (var, indices) in zip(va_state.vars, va_state.indices)
-        println(io, "        $(PB.fullname(var))  indices $indices")
-        push!(vinner_names, PB.fullname(var))
-        push!(inner_domains, var.domain)
-        push!(vinner_indices, indices)
-    end
-    inner_domains =unique(inner_domains)
-    length(inner_domains) == 1 || error("TODO only 1 Domain with algebraic constraints supported, Domains=$vinner_domains")
-    inner_domain = inner_domains[1]
-    # find cellranges for Domains with algebraic constraints
-    cellrange_inner = PB.Grids.create_default_cellrange(inner_domain, inner_domain.grid, operatorID=operatorID_inner)
-    println(io, "    inner Newton solve Domain $inner_domain, cellrange $cellrange_inner")
+    # sparsity pattern for outer Jacobian
+    ijrange_outer = 1:length(va_stateexplicit) # indices of 'outer' variables
+    # ri = (length(va_stateexplicit)+1):length(initial_state)
+    jacouter_prototype = jacfull_prototype[ijrange_outer, ijrange_outer]
 
-    # create a modeldata_ad with Dual numbers for AD Jacobians for 'inner' Newton solve
-    n_inner_solve = length(vinner_names)
-    println(io, "   using ForwardDiff dense Jacobian for inner Newton solve")
-    @info String(take!(io))
-    eltype_inner_ad = ForwardDiff.Dual{Nothing, eltype(modeldata), n_inner_solve}
-    _, modeldata_ad_inner = Logging.with_logger(init_logger) do
-        PALEOmodel.initialize!(model, eltype=eltype_inner_ad)
+    # include contributions from inner state Variables    
+    jacouter_implicit = SparseArrays.spzeros(size(jacouter_prototype))
+    dG_dcellinner_lu = nothing
+    jacinner_prototype = nothing
+   
+    for (cidx, sci, cci) in zip(cellrange_inner.indices, cellstateidxfull, cellconstraintsidxfull)
+        dG_dcellinner = jacfull_prototype[cci, sci] # n_inner x n_inner (sparsity pattern of Jacobian for inner solve)
+        if isnothing(jacinner_prototype)
+            jacinner_prototype = copy(dG_dcellinner)
+        else
+            # check sparsity pattern
+            dG_dcellinner == jacinner_prototype || error("cell $cidx sparsity pattern for inner Jacobian does not match")
+        end
+
+        dG_douter = jacfull_prototype[cci, ijrange_outer] # n_inner x n_outer
+        
+        # try and generate a non-singular matrix by setting values
+        for i in eachindex(dG_dcellinner.nzval)
+            dG_dcellinner.nzval[i] = i
+        end
+        # dcellinner_dcellouter = -dG_dcellinner \ dG_douter # n_inner x n_outer
+        if isnothing(dG_dcellinner_lu)
+            dG_dcellinner_lu = LinearAlgebra.lu(dG_dcellinner)
+        else
+            LinearAlgebra.lu!(dG_dcellinner_lu, dG_dcellinner)
+        end
+        # \ is not implemented, so as a workaround get an inverse with the correct sparsity
+        dG_dcellinner_inv = SparseUtils.get_sparse_inverse(dG_dcellinner)
+
+        @debug "cell $cidx dG_dcellinner dG_dcellinner_inv" dG_dcellinner dG_dcellinner_inv
+
+        # @Infiltrator.infiltrate
+        dcellinner_dcellouter = -dG_dcellinner_inv * dG_douter # n_inner x n_outer
+
+        # n_outer x n_outer  +=  n_outer x n_inner  * n_inner x n_outer
+        jacouter_implicit += jacfull_prototype[ijrange_outer, sci]*dcellinner_dcellouter 
     end
-    va_inner_stateexplicit = modeldata_ad_inner.solver_view_all.stateexplicit
-    @info "split_dae:  Variables to be copied from 'modeldata' before inner Newton solve Jacobian calculation:"
+
+    # combine to get full sparsity pattern
+    io = IOBuffer()
+    println(io, "create_split_dae:")
+    println(io, "    calculating 'outer' Jacobian sparsity pattern:")
+    println(io, "        jacouter (outer variables, $(size(jacouter_prototype))): nnz=$(SparseArrays.nnz(jacouter_prototype))")
+    println(io, "        jacouter_implicit (from inner variables): nnz=$(SparseArrays.nnz(jacouter_implicit))")
+    jacouter_implicit.nzval .= 1.0  # fill with 1.0 to avoid any risk of spurious cancellations
+    jacouter_prototype += jacouter_implicit
+    println(io, "        jacouter (all variables):")
+    jacouter_prototype = SparseUtils.fill_sparse_jac(jacouter_prototype; val=1.0, fill_diagonal=true)
+
+    #########################################################################
+    # create a modeldata_jaccell with Dual numbers for AD Jacobians for 'inner' Newton solve
+    #####################################################################
+
+    if inner_jac_ad == :ForwardDiff
+        println(io, "    using ForwardDiff dense Jacobian for inner Newton solve")   
+        eltype_jaccell = ForwardDiff.Dual{Nothing, eltype(modeldata), n_inner_solve}
+
+    elseif inner_jac_ad == :ForwardDiffSparse
+       
+        colorvec = SparseDiffTools.matrix_colors(jacinner_prototype)
+        jacinner_chunksize = ForwardDiff.pickchunksize(maximum(colorvec), request_adchunksize)
+        eltype_jaccell = ForwardDiff.Dual{Nothing, eltype(modeldata), jacinner_chunksize}
+        
+        println(io, "    using ForwardDiffSparse Jacobian for inner Newton solve colors $(maximum(colorvec)) chunksize $jacinner_chunksize") 
+
+        jacinner_cache = SparseDiffTools.ForwardColorJacCache(
+            nothing, cellworksp, jacinner_chunksize;
+            dx = nothing, # not needed for square Jacobian
+            colorvec=colorvec,
+            sparsity = copy(jacinner_prototype)
+        )
+    else
+        error("unrecognized inner_jac_ad $inner_jac_ad")
+    end
+
+    _, modeldata_jaccell = Logging.with_logger(init_logger) do
+        PALEOmodel.initialize!(model, eltype=eltype_jaccell)
+    end
+    va_stateexplicit_jaccell = modeldata_jaccell.solver_view_all.stateexplicit
+    println(io, "    Variables to be copied from 'modeldata' before inner Newton solve Jacobian calculation:")
+    @info String(take!(io))
     # any Variables calculated by modelode but not jacode, that need to be copied
-    transfer_data_ad_inner, transfer_data_inner = PALEOmodel.JacobianAD.jac_transfer_variables(
+    transfer_data_inner_jaccell, transfer_data_inner = PALEOmodel.JacobianAD.jac_transfer_variables(
         model,
-        modeldata_ad_inner,
+        modeldata_jaccell,
         modeldata;
         extra_vars=transfer_inner_vars
     )
 
-    # construct function objects to calculate per-cell constraint and Jacobian for 'inner' Variables
-    cellindex, cellderivs, celljacs, cellvaridxfull, cellinitialstates = [], [], [], [], []
-    cellworksp = fill(NaN, n_inner_solve)
-    cellworksp_ad = fill(eltype_inner_ad(NaN), n_inner_solve)
-   
-    for i in cellrange_inner.indices
-        push!(cellindex, i)
-        cellrange = PB.CellRange(cellrange_inner.domain, cellrange_inner.operatorID, i)
-        vars_cellranges = [cellrange for i in 1:length(va_state.vars)]
-        # modeldata Arrays to calculate residual
-        va_cell_state = PB.VariableAggregator(va_state.vars, vars_cellranges, modeldata)
-        cell_initial_state = Vector{eltype(modeldata)}(undef, n_inner_solve)
-        copyto!(cell_initial_state, va_cell_state)
-        push!(cellinitialstates, cell_initial_state)
-        va_cell_constraints = PB.VariableAggregator(va_constraints.vars, vars_cellranges, modeldata)
-        va_cell_dl = PB.create_dispatch_methodlists(model, modeldata, [cellrange])
-        push!(cellderivs, ModelDerivCell(n_inner_solve, modeldata, va_cell_state, va_cell_constraints, va_cell_dl, cellworksp))
-       
-        # modeldata_ad_inner Arrays to calculate Jacobian using ForwardDiff
-        va_cell_state_ad = PB.VariableAggregator(va_state.vars, vars_cellranges, modeldata_ad_inner)
-        va_cell_constraints_ad = PB.VariableAggregator(va_constraints.vars, vars_cellranges, modeldata_ad_inner)
-        va_cell_dl_ad = PB.create_dispatch_methodlists(model, modeldata_ad_inner, [cellrange])
-        push!(celljacs, ModelJacForwardDiffCell(ModelDerivCell(n_inner_solve, modeldata_ad_inner, va_cell_state_ad, va_cell_constraints_ad, va_cell_dl_ad, cellworksp_ad)))
-        # index in full model for each Variable
-        va_cell_idx = [indices[i] + length(va_outer_state) for indices in va_state.indices]
-        push!(cellvaridxfull, va_cell_idx)
+    ###########################################################
+    # construct function objects to calculate per-cell Jacobian for 'inner' Variables
+    ##################################
+    jaccells = []
+    cellworksp_jaccell = fill(eltype_jaccell(NaN), n_inner_solve)
+    cellworksp_jacsparse = copy(jacinner_prototype)
+    for cellrange in cellcellranges
+        # modeldata_jaccell Arrays to calculate constraints, with appropriate Dual number element type
+        vars_cellranges = fill(cellrange, n_inner_solve)
+        va_cell_state_jaccell = PB.VariableAggregator(va_state.vars, vars_cellranges, modeldata_jaccell)
+        va_cell_constraints_jaccell = PB.VariableAggregator(va_constraints.vars, vars_cellranges, modeldata_jaccell)
+        va_cell_dl_jaccell = PB.create_dispatch_methodlists(model, modeldata_jaccell, [cellrange])
+
+        # function object to calculate constraints, with appropriate Dual number element type
+        constraintscell = ModelDerivCell(
+            n_inner_solve, modeldata_jaccell, va_cell_state_jaccell, va_cell_constraints_jaccell, va_cell_dl_jaccell, cellworksp_jaccell
+        )
+
+        # function object to calculate per-cell Jacobian
+        if inner_jac_ad == :ForwardDiff
+            jaccell = ModelJacForwardDiffCell(constraintscell)
+        elseif inner_jac_ad == :ForwardDiffSparse
+            jaccell = ModelJacForwardDiffSparseCell(
+                constraintscell,
+                cellworksp_jacsparse,
+                jacinner_cache,
+                dG_dcellinner_lu
+            )
+        else
+            error("unrecognized inner_jac_ad $inner_jac_ad")
+        end
+
+        push!(jaccells, jaccell)
     end
-
-    # sparsity pattern for outer Jacobian
-    ro = 1:length(va_outer_state) # indices of 'outer' variables
-    ri = (length(va_outer_state)+1):length(initial_state)
-    jacouter_prototype = jacfull_prototype[ro, ro]
-
-    # include contributions from inner state Variables
-    dG_dcellinner = jacfull_prototype[ri, ri] # n_inner x n_inner
-    dG_douter = jacfull_prototype[ri, ro] # n_inner x n_outer
-    # try and generate a non-singular matrix by setting values
-    for i in eachindex(dG_dcellinner.nzval)
-        dG_dcellinner.nzval[i] = i
-    end
-    # dcellinner_dcellouter = -dG_dcellinner \ dG_douter # n_inner x n_outer
-    # \ is not implemented for sparse RHS, so as a workaround, get an inverse with the correct sparsity    
-    dG_dcellinner_inv = get_sparse_inverse(dG_dcellinner)  
-    dcellinner_dcellouter = -dG_dcellinner_inv * dG_douter # n_inner x n_outer
-
-    # n_outer x n_outer  +=  n_outer x n_inner  * n_inner x n_outer
-    jacouter_implicit = jacfull_prototype[ro, ri]*dcellinner_dcellouter
-    jacouter_implicit.nzval .= 1
-
-    # combine to get full sparsity pattern
-    io = IOBuffer()
-    println(io, "split_dae:")
-    println(io, "    calculating 'outer' Jacobian sparsity pattern:")
-    println(io, "        jacouter (outer variables, $(size(jacouter_prototype))): nnz=$(SparseArrays.nnz(jacouter_prototype))")
-    println(io, "        jacouter_implicit (from inner variables): nnz=$(SparseArrays.nnz(jacouter_implicit))")
-    jacouter_prototype += jacouter_implicit
-    jacouter_prototype.nzval .= 1
-    println(io, "        jacouter (all variables): nnz=$(SparseArrays.nnz(jacouter_prototype))")
-    @info String(take!(io))
-
+    
     ms = ModelSplitDAE(
         modeldata,
         sva,
@@ -201,21 +306,24 @@ function create_split_dae(
         dispatchlists_recalc_deriv,
         jacfull,
         copy(jacfull_prototype),
-        transfer_data_ad,
+        transfer_data_jacfull,
         transfer_data,
-        transfer_data_ad_inner,
+        transfer_data_inner_jaccell,
         transfer_data_inner,
-        va_outer_state,
-        va_outer_state_deriv,
-        va_inner_stateexplicit,
-        [c for c in cellindex], # narrow type
+        va_stateexplicit,
+        va_stateexplicit_deriv,
+        va_stateexplicit_jaccell,
+        copy(collect(cellrange_inner.indices)),
         [c for c in cellderivs], # narrow type
-        [c for c in celljacs], # narrow type
-        [c for c in cellvaridxfull], # narrow_type
+        [c for c in jaccells], # narrow type
+        [c for c in cellstateidxfull], # narrow_type
+        [c for c in cellconstraintsidxfull], # narrow_type
         [c for c in cellinitialstates], # narrow_type
         inner_kwargs,
         similar(initial_state_outer),
         similar(initial_state),
+        dG_dcellinner_lu,
+        cellworksp_jacsparse,
     )
 
     return (ms, initial_state_outer, jacouter_prototype)
@@ -235,35 +343,38 @@ Provides functions for outer derivative and Jacobian:
     (ms::ModelSplitDAE)(du_outer::AbstractVector, J_outer::SparseArrays.AbstractSparseMatrixCSC, u_outer::AbstractVector, p, t)    
 
 """
-struct ModelSplitDAE{T, SVA, DLA, DLR, JF, TD1, TD2, TD3, TD4, VA1, VA2, VA3, CD, CJ, IK}
+struct ModelSplitDAE{T, SVA, DLA, DLR, JF, TD1, TD2, TD3, TD4, VA1, VA2, VA3, CD, CJ, IK, LU}
     modeldata::PB.ModelData{T}
     solver_view_all::SVA
     dispatchlists_all::DLA
     dispatchlists_recalc_deriv::DLR
     jacfull::JF
     jacfull_ws::SparseArrays.SparseMatrixCSC{T, Int64}
-    transfer_data_ad::TD1
+    transfer_data_jacfull::TD1
     transfer_data::TD2
-    transfer_data_ad_inner::TD3
+    transfer_data_inner_jaccell::TD3
     transfer_data_inner::TD4
-    va_outer_state::VA1
-    va_outer_state_deriv::VA2
-    va_inner_stateexplicit::VA3
+    va_stateexplicit::VA1
+    va_stateexplicit_deriv::VA2
+    va_stateexplicit_jaccell::VA3
     cellindex::Vector{Int64}
     cellderivs::CD
-    celljacs::CJ    
-    cellvaridxfull::Vector{Vector{Int64}}
+    jaccells::CJ    
+    cellstateidxfull::Vector{Vector{Int64}}
+    cellconstraintsidxfull::Vector{Vector{Int64}}
     cellinitialstates::Vector{Vector{Float64}}
     inner_kwargs::IK    
     outer_worksp::Vector{T}
     full_worksp::Vector{T}
+    dG_dcellinner_lu::LU
+    jacinner_ws::SparseArrays.SparseMatrixCSC{T, Int64}
 end
 
 # calculate ODE derivative for outer Variables, with inner Newton solve for algebraic constraints
 function (ms::ModelSplitDAE)(du_outer::AbstractVector, u_outer::AbstractVector, p, t)
     
     # set outer state Variables
-    copyto!(ms.va_outer_state, u_outer)
+    copyto!(ms.va_stateexplicit, u_outer)
     # NB: inner state Variables are set below
 
     # full derivative, with old values of inner state variables  
@@ -272,14 +383,14 @@ function (ms::ModelSplitDAE)(du_outer::AbstractVector, u_outer::AbstractVector, 
 
     # copy Variables to inner AD Variables 
     # explicitly requested Variables (eg grid geometry, photochemical rates, ...)
-    for (dto, dfrom) in PB.IteratorUtils.zipstrict(ms.transfer_data_ad_inner, ms.transfer_data_inner)
+    for (dto, dfrom) in PB.IteratorUtils.zipstrict(ms.transfer_data_inner_jaccell, ms.transfer_data_inner)
         dto .= dfrom
     end
     # always set all outer state variables (inner state variables will be solved for)
-    copyto!(ms.va_inner_stateexplicit, u_outer)
+    copyto!(ms.va_stateexplicit_jaccell, u_outer)
 
     # Newton solution for inner state Variables for each cell
-    for (ci, cd, cj, cs) in PB.IteratorUtils.zipstrict(ms.cellindex, ms.cellderivs, ms.celljacs, ms.cellinitialstates)
+    for (ci, cd, cj, cs) in PB.IteratorUtils.zipstrict(ms.cellindex, ms.cellderivs, ms.jaccells, ms.cellinitialstates)
         # use current value (from previous iteration) as starting value
         # copyto!(cd.worksp, cd.state)
         # initial_state = StaticArrays.SVector{ncomps(cd)}(cd.worksp)
@@ -295,14 +406,14 @@ function (ms::ModelSplitDAE)(du_outer::AbstractVector, u_outer::AbstractVector, 
     end
 
     # reevaluate full derivative with updated inner state variables
-    # TODO this could be optimized eg don't need to rerun radiative transfer
+    # use dispatchlists_recalc_deriv if available (an optimization, eg don't need to rerun radiative transfer)
     if !isnothing(ms.dispatchlists_recalc_deriv)
         PB.do_deriv(ms.dispatchlists_recalc_deriv)
     else
         PB.do_deriv(ms.dispatchlists_all)
     end
     
-    copyto!(du_outer, ms.va_outer_state_deriv)
+    copyto!(du_outer, ms.va_stateexplicit_deriv)
 
     return nothing
 end
@@ -323,7 +434,7 @@ function (ms::ModelSplitDAE)(du_outer::AbstractVector, J_outer::SparseArrays.Abs
     ms(du_outer, u_outer, p, t)
 
     # transfer Variables that are not included in Jacobian
-    for (dto, dfrom) in PB.IteratorUtils.zipstrict(ms.transfer_data_ad, ms.transfer_data)
+    for (dto, dfrom) in PB.IteratorUtils.zipstrict(ms.transfer_data_jacfull, ms.transfer_data)
         dto .= dfrom
     end
 
@@ -334,28 +445,53 @@ function (ms::ModelSplitDAE)(du_outer::AbstractVector, J_outer::SparseArrays.Abs
     J_full.nzval .= 0.0
     ms.jacfull(J_full, u_full, p, t)
 
-    # calculate outer Jacobian using implicit function theorum
+    # calculate Jacobian of outer Variables 'J_outer' using implicit function theorum
     J_outer.nzval .= 0.0
-    # Jacobian of outer Variables
-    ro = 1:size(J_outer, 1)
-    # NB: this changes the size (stored elements) of J_outer !!
+    ijrange_outer = 1:size(J_outer, 1)
+    # NB: .= changes the size (stored elements) of J_outer !!
     # J_outer .= J_full[ro, ro]
-    add_sparse_fixed!(J_outer, J_full[ro, ro]) # TODO use view
+    SparseUtils.add_sparse_fixed!(J_outer, (@view J_full[ijrange_outer, ijrange_outer]))
 
-    # add contributions per-cell from inner Variables using implicit function theorum    
-    for ci in ms.cellvaridxfull
-        dG_dcellinner = view(J_full, ci, ci) # n_inner x n_inner (TODO could also get this from jac used for inner solve)
-        dG_douter = J_full[ci, ro] # n_inner x n_outer - don't use view as view(sparse)*sparse is very slow
+    # add contributions per-cell from inner Variables using implicit function theorum
+    
+    # pseudocode for simple version
+    # (in Julia 1.7 this hits some unimplemented operations and slow fallbacks)
+    #
+    # for (sci, cci) in zip(ms.cellstateidxfull, ms.cellconstraintsidxfull)
+    #     dG_dcellinner = J_full[cci, sci] # n_inner x n_inner (TODO could also get this from jac used for inner solve)
+    #
+    #     dG_douter = J_full[cci, ijrange_outer] # n_inner x n_outer
+    #    
+    #     dcellinner_dcellouter = -dG_dcellinner \ dG_douter # n_inner x n_outer (not implemented in Julia 1.7)
+    #
+    #     n_outer x n_outer  +=  n_outer x n_inner  * n_inner x n_outer
+    #     J_outer .+= J_full[ijrange_outer, sci]*dcellinner_dcellouter   # modifies sparsity pattern of J_outer !
+    # end
+
+    # per-column version
+    dG_douter = zeros(length(first(ms.cellstateidxfull)))
+    dcellinner_dcellouter = similar(dG_douter)
+    tmpcol = ms.outer_worksp # length(ro)
+    for (sci, cci) in zip(ms.cellstateidxfull, ms.cellconstraintsidxfull)
+        dG_dcellinner = J_full[cci, sci] # n_inner x n_inner (TODO could also get this from jac used for inner solve)
+
+        LinearAlgebra.lu!(ms.dG_dcellinner_lu, dG_dcellinner)
+        # per-column loop
+        for j_outer in ijrange_outer
+            # dG_douter = J_full[cci, j_outer]
+            # if !iszero(SparseUtils.get_column_sparse!(dG_douter, (@view J_full[cci, j_outer]))) # view is slow
+            if !iszero(SparseUtils.get_column_sparse!(dG_douter, J_full, cci, j_outer))
         
-        # dcellinner_dcellouter = -dG_dcellinner \ dG_douter # n_inner x n_outer
-        # \ is not implemented, so as a workaround get an inverse with the correct sparsity
-        dG_dcellinner_inv = get_sparse_inverse(dG_dcellinner)
-        dcellinner_dcellouter = -dG_dcellinner_inv * dG_douter # n_inner x n_outer
+                dcellinner_dcellouter .= ms.dG_dcellinner_lu \ dG_douter # n_inner
+                dcellinner_dcellouter .*= -1.0
 
-        # n_outer x n_outer  +=  n_outer x n_inner  * n_inner x n_outer
-        # NB: this changes the size (stored elements) of J_outer !!
-        # J_outer .+= J_full[ro, ci]*dcellinner_dcellouter 
-        add_sparse_fixed!(J_outer, J_full[ro, ci]*dcellinner_dcellouter)
+                # nouter x 1 = nouter x ninner * ninner
+                # tmpcol .= J_full[ijrange_outer, sci]*dcellinner_dcellouter
+                SparseUtils.mult_sparse_vec!(tmpcol, (@view J_full[ijrange_outer, sci]), dcellinner_dcellouter)
+                # J_outer[:, j_outer] += tmpcol
+                SparseUtils.add_column_sparse_fixed!((@view J_outer[:, j_outer]), tmpcol)
+            end
+        end
     end
 
     return nothing
@@ -377,6 +513,7 @@ end
 
 ncomps(md::ModelDerivCell{Ncomps, T, VA1, VA2, D}) where {Ncomps, T, VA1, VA2, D} = Ncomps
 
+# out-of-place SVector
 function (md::ModelDerivCell)(x::StaticArrays.SVector)
     # @Infiltrator.infiltrate
     copyto!(md.state, x)
@@ -386,70 +523,48 @@ function (md::ModelDerivCell)(x::StaticArrays.SVector)
     return StaticArrays.SVector{ncomps(md)}(md.worksp)
 end
 
+# in place Vector
+function (md::ModelDerivCell)(y::AbstractVector, x::AbstractVector)
+    # @Infiltrator.infiltrate
+    copyto!(md.state, x)
+    PB.do_deriv(md.dispatchlists, 0.0)
+    copyto!(y, md.deriv)
+
+    return nothing
+end
+
 # calculate Jacobian for a single cell
-mutable struct ModelJacForwardDiffCell{MD}
+struct ModelJacForwardDiffCell{MD}
     modelderiv::MD
 end
 
 function (mjfd::ModelJacForwardDiffCell)(x::StaticArrays.SVector)
-    # TODO ForwardDiff doesn't provide an API to 
+    # TODO ForwardDiff doesn't provide an API to get jacobian without setting Dual number 'tag'
     return ForwardDiff.extract_jacobian(Nothing, ForwardDiff.static_dual_eval(Nothing, mjfd.modelderiv, x), x)
 end
 
-
-
-
-###############################################
-# Sparse matrix additional functions
-###############################################
-
-"""
-    add_sparse_fixed!(A, B)
-
-Sparse matrix `A .+= B`, without modifying sparsity pattern of `A`.
-
-Errors if `B` contains elements not in sparsity pattern of `A`
-
-    julia> A = SparseArrays.sparse([1, 4], [2, 3], [1.0, 1.0], 4, 4)
-    julia> B = SparseArrays.sparse([1], [2], [2.0], 4, 4)
-    julia> SplitDAE.add_sparse_fixed!(A, B) # OK
-    julia> C = SparseArrays.sparse([2], [2], [2.0], 4, 4)
-    julia> SplitDAE.add_sparse_fixed!(A, C) # errors
-
-TODO views, SubArray{Float64, 2, SparseArrays.SparseMatrixCSC{Float64, Int64}}
-"""
-function add_sparse_fixed!(A::SparseArrays.SparseMatrixCSC, B::SparseArrays.SparseMatrixCSC)
-    size(A) == size(B) || error("A and B are not the same size")
-
-    for j in 1:size(B, 2)
-        idx_A = A.colptr[j]
-        for idx_B in B.colptr[j]:(B.colptr[j+1]-1)
-            i_B = B.rowval[idx_B]
-            while idx_A < A.colptr[j+1] && A.rowval[idx_A] != i_B
-                idx_A += 1
-            end
-            idx_A < A.colptr[j+1] || error("element [$i_B, $j] in B is not present in A")
-            A.nzval[idx_A] += B.nzval[idx_B]
-        end
-    end
-    return A
+# calculate lu factorization of sparse Jacobian for a single cell
+struct ModelJacForwardDiffSparseCell{MD, JWS <: SparseArrays.SparseMatrixCSC, JC <: SparseDiffTools.ForwardColorJacCache, L}
+    modelderiv::MD
+    jac_ws::JWS
+    jac_cache::JC
+    jac_lu::L
 end
 
-# horrible hack to get a sparse inverse
-# workaround for missing functions to calculate A \ x for sparse x ie preserving sparsity
-function get_sparse_inverse(A)
+function (mjfd::ModelJacForwardDiffSparseCell)(x::AbstractVector)
+    SparseDiffTools.forwarddiff_color_jacobian!(
+        mjfd.jac_ws,
+        mjfd.modelderiv,
+        x,
+        mjfd.jac_cache,
+    )
 
-    # get an inverse with the correct sparsity    
-    # find dense inverse
-    A_inv_dense = LinearAlgebra.inv(Matrix(A))
-    # reconstruct a sparse matrix
-    ij = Tuple.(findall(!iszero, A_inv_dense))
-    I = [i for (i,j) in ij]
-    J = [j for (i,j) in ij]
-    V = [A_inv_dense[i, j] for (i, j) in ij]
-    A_inv = SparseArrays.sparse(I, J, V)
+    LinearAlgebra.lu!(mjfd.jac_lu, mjfd.jac_ws)
 
-    return A_inv
+    return mjfd.jac_lu
 end
+
+
+
 
 end # module

--- a/src/SteadyState.jl
+++ b/src/SteadyState.jl
@@ -287,6 +287,7 @@ As [`steadystate_ptc`](@ref), with an inner Newton solve for per-cell algebraic 
 - `operatorID_inner=3`: operatorID for Reactions to run for inner solve (typically all reservoirs and chemical reactions)
 - `transfer_inner_vars=["tmid", "volume", "ntotal", "Abox"]`: Variables not calculated by `operatorID_inner` that need to be copied for 
   inner solve (additional to those with `transfer_jacobian` set).
+- `inner_jac_ad::Symbol=:ForwardDiff`: form of automatic differentiation to use for Jacobian for inner `NonlinearNewton.solve` solver (options `:ForwardDiff`, `:ForwardDiffSparse`)
 - `inner_kwargs::NamedTuple=(verbose=0, miniters=2, reltol=1e-12, jac_constant=true, u_min=1e-60)`: keywords for inner 
   `NonlinearNewton.solve` solver.
 """
@@ -303,7 +304,8 @@ function steadystate_ptc_splitdae(
     sol_min=-Inf,
     verbose=false,
     operatorID_inner=3,
-    transfer_inner_vars=["tmid", "volume", "ntotal", "Abox"], 
+    transfer_inner_vars=["tmid", "volume", "ntotal", "Abox"],
+    inner_jac_ad=:ForwardDiff,
     inner_kwargs::NamedTuple=(verbose=0, miniters=2, reltol=1e-12, jac_constant=true, u_min=1e-60),
     BLAS_num_threads=1
 )
@@ -315,7 +317,8 @@ function steadystate_ptc_splitdae(
         request_adchunksize=request_adchunksize,
         operatorID_inner=operatorID_inner,
         transfer_inner_vars=transfer_inner_vars,
-        tss_jac_sparsity=tspan[1], 
+        tss_jac_sparsity=tspan[1],
+        inner_jac_ad=inner_jac_ad, 
         inner_kwargs=inner_kwargs,
     )
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,4 +14,6 @@ include("runkinsoltests.jl")
 
 include("runoutputwritertests.jl")
 
+include("testsparseutils.jl")
+
 end

--- a/test/testsparseutils.jl
+++ b/test/testsparseutils.jl
@@ -1,0 +1,72 @@
+using Test
+using Logging
+
+import SparseArrays
+import PALEOmodel
+
+const SU = PALEOmodel.SparseUtils
+
+@testset "SparseUtils" begin
+    
+@testset "add_sparse_fixed!" begin
+    A = SparseArrays.sprand(10, 10, 1e-1)
+
+    A_copy = copy(A)
+    SU.add_sparse_fixed!(A_copy, A)
+    @test A_copy == 2*A
+
+    A_copy = copy(A)
+    A_full = similar(A)
+    fill!(A_full, 1.0)
+    @test_throws ErrorException SU.add_sparse_fixed!(A_copy, A_full)
+
+    A_copy = A[2:5, 3:5]
+    SU.add_sparse_fixed!(A_copy, view(A, 2:5, 3:5))
+    @test A_copy == 2*A[2:5, 3:5]
+end
+
+@testset "get_column_sparse!" begin
+    A = SparseArrays.sprand(10, 10, 1e-1)
+
+    x = ones(10)
+    for j in 1:10
+        num_nonzero = SU.get_column_sparse!(x, view(A, :, j))
+        @test x == A[:, j]
+        @test num_nonzero == count(!iszero, A[:, j])
+    end
+
+    x = ones(7)
+    for j in 1:10
+        num_nonzero = SU.get_column_sparse!(x, view(A, 2:8, j))
+        @test x == A[2:8, j]
+        @test num_nonzero == count(!iszero, A[2:8, j])
+    end
+end
+
+@testset "add_column_sparse_fixed!" begin
+    A = SparseArrays.sprand(10, 10, 1e-1)
+
+    for j in 1:10
+        x = Vector(A[:, j])
+        A_copy = copy(A)
+        SU.add_column_sparse_fixed!(view(A_copy, :, j), x)
+        @test A_copy[:, j] == 2*A[:, j]
+    end
+    
+end
+
+@testset "mult_sparse_vec!" begin
+    A = SparseArrays.sprand(10, 10, 1e-1)
+
+    x = ones(6)
+    y = ones(3)
+
+    SU.mult_sparse_vec!(y, view(A, 5:7, 2:7), x)
+    @test y == A[5:7, 2:7]*x
+
+    SU.mult_sparse_vec!(y, (@view A[5:7, 2:7]), x)
+    @test y == A[5:7, 2:7]*x
+
+end
+
+end


### PR DESCRIPTION
Fixes and updates for SplitDAE solver
- fixes for Jacobian sparsity calculation: don't automatically fill diagonal, order state and constraint Variables to generate a near-diagonal Jacobian
- optimisation for SplitDAE solver: optimised versions of some special cases of sparse matrix operations (in SparseUtils.jl)
- option to use ForwardDiffSparse for inner Jacobian (seems to be very comparable to dense ForwardDiff for speed and accuracy)