### PR TITLE
Workaround for issues with ForwardDiff.jl v0.10.35

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PALEOmodel"
 uuid = "bf7b4fbe-ccb1-42c5-83c2-e6e9378b660c"
 authors = ["Stuart Daines <stuart.daines@gmail.com>"]
-version = "0.15.19"
+version = "0.15.18"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -32,11 +32,11 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 DataFrames = "1.1"
 DiffRules = "1.0"
 FileIO = "1.0"
-ForwardDiff = "0.10"
+ForwardDiff = "0.10 - 0.10.34"
 Infiltrator = "1.0"
 JLD2 = "0.4"
 NLsolve = "4.5"
-PALEOboxes = "0.21.7"
+PALEOboxes = "0.21.5"
 RecipesBase = "1.2"
 Requires = "1.0"
 Revise = "3.1"


### PR DESCRIPTION
See issue https://github.com/PALEOtoolkit/PALEOmodel.jl/issues/40

Something in the vicinity of extract_jacobian changed in the latest release of ForwardDiff.jl v0.10.35 : JuliaDiff/ForwardDiff.jl@04f76ca

This causes failures with steadystate_ptc_splitdae solver under as-yet-unknown circumstances - possibly Julia version dependent ? (not so far reproducable with Julia 1.8.4, 1.9.0-beta4)

Workaround: restrict version of ForwardDiff.jl < 0.10.35