### PR TITLE
Workaround for ForwardDiff with StaticArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PALEOmodel"
 uuid = "bf7b4fbe-ccb1-42c5-83c2-e6e9378b660c"
 authors = ["Stuart Daines <stuart.daines@gmail.com>"]
-version = "0.15.21"
+version = "0.15.22"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/src/SplitDAE.jl
+++ b/src/SplitDAE.jl
@@ -6,11 +6,11 @@ import PALEOmodel
 
 import LinearAlgebra
 import SparseArrays
+import StaticArrays
 import ForwardDiff
 import SparseDiffTools
 import Infiltrator
 using Logging
-import StaticArrays
 import TimerOutputs: @timeit, @timeit_debug
 
 import NLsolve
@@ -533,15 +533,51 @@ end
 # TODO ForwardDiff doesn't provide an API to get jacobian without setting Dual number 'tag'
 @static if isdefined(ForwardDiff, :extract_jacobian) # ForwardDiff v < 0.10.35
     const _forwarddiff_static_module = ForwardDiff
+    const _extract_jacobian = _forwarddiff_static_module.extract_jacobian
+    const _static_dual_eval = _forwarddiff_static_module.static_dual_eval
 elseif isdefined(ForwardDiff, :ForwardDiffStaticArraysExt) # ForwardDiff >= 0.10.35, Julia < 1.9
     const _forwarddiff_static_module = ForwardDiff.ForwardDiffStaticArraysExt
+    const _extract_jacobian = _forwarddiff_static_module.extract_jacobian
+    const _static_dual_eval = _forwarddiff_static_module.static_dual_eval
 else # ForwardDiff >= 0.10.35, Julia >= 1.9    
     const _forwarddiff_static_module = Base.get_extension(ForwardDiff, :ForwardDiffStaticArraysExt)
+    # get_extension fails with Julia 1.9.0-rc2 ??
+    if isnothing(_forwarddiff_static_module)
+        @warn "isnothing(Base.get_extension(ForwardDiff, :ForwardDiffStaticArraysExt)) - using workaround, reimplementing ForwardDiffStaticArraysExt extract_jacobian etc"
+
+        @generated function _extract_jacobian(::Type{T}, ydual::StaticArrays.StaticArray, x::S) where {T,S<:StaticArrays.StaticArray}
+            M, N = length(ydual), length(x)
+            result = Expr(:tuple, [:(ForwardDiff.partials(T, ydual[$i], $j)) for i in 1:M, j in 1:N]...)
+            return quote
+                $(Expr(:meta, :inline))
+                V = StaticArrays.similar_type(S, ForwardDiff.valtype(eltype($ydual)), StaticArrays.Size($M, $N))
+                return V($result)
+            end
+        end
+
+        @generated function _dualize(::Type{T}, x::StaticArrays.StaticArray) where T
+            N = length(x)
+            dx = Expr(:tuple, [:(ForwardDiff.Dual{T}(x[$i], chunk, Val{$i}())) for i in 1:N]...)
+            V = StaticArrays.similar_type(x, ForwardDiff.Dual{T,eltype(x),N})
+            return quote
+                chunk = ForwardDiff.Chunk{$N}()
+                $(Expr(:meta, :inline))
+                return $V($(dx))
+            end
+        end
+
+        @inline _static_dual_eval(::Type{T}, f, x::StaticArrays.StaticArray) where T = f(_dualize(T, x))
+    else
+        const _extract_jacobian = _forwarddiff_static_module.extract_jacobian
+        const _static_dual_eval = _forwarddiff_static_module.static_dual_eval
+    end
 end
+
 
 function (mjfd::ModelJacForwardDiffCell)(x::StaticArrays.SVector)
     # TODO ForwardDiff doesn't provide an API to get jacobian without setting Dual number 'tag'
-    return _forwarddiff_static_module.extract_jacobian(Nothing,  _forwarddiff_static_module.static_dual_eval(Nothing, mjfd.modelderiv, x), x)
+    # return _forwarddiff_static_module.extract_jacobian(Nothing,  _forwarddiff_static_module.static_dual_eval(Nothing, mjfd.modelderiv, x), x)
+    return _extract_jacobian(Nothing,  _static_dual_eval(Nothing, mjfd.modelderiv, x), x)
 end
 
 # calculate lu factorization of sparse Jacobian for a single cell


### PR DESCRIPTION
With Julia 1.9.0-rc2,
Base.get_extension(ForwardDiff, :ForwardDiffStaticArraysExt) fails (returns nothing)

Workaround - reimplement extract_jacobian etc from ForwardDiffStaticArraysExt