### PR TITLE
Robustness fix for SteadyState.steadystate_ptc_splitdae solver

### DIFF
--- a/src/JacobianAD.jl
+++ b/src/JacobianAD.jl
@@ -53,6 +53,7 @@ NB: there is a profusion of different Julia APIs here:
 - `request_adchunksize=ForwardDiff.DEFAULT_CHUNK_THRESHOLD`:  chunk size for `ForwardDiff` automatic differentiation
 - `fill_jac_diagonal=true`: (`jac=:ForwardDiffSparse` only) true to fill diagonal of `jac_prototype`
 - `generated_dispatch=true`: `true` to autogenerate code for dispatch (fast dispatch, slow compile)
+- `throw_on_nan=false`: `true` to error if NaN detected in Jacobian
 - `use_base_vars=String[]`: additional Variable full names not calculated by Jacobian, which instead use arrays from `modeldata` base arrays (arrays_idx=1) instead of allocating new AD Variables
 """
 function jac_config_ode(
@@ -61,6 +62,7 @@ function jac_config_ode(
     request_adchunksize=ForwardDiff.DEFAULT_CHUNK_THRESHOLD,
     fill_jac_diagonal=true,
     generated_dispatch=true,
+    throw_on_nan=false,
     use_base_vars=String[],
 )
     @info "jac_config_ode: jac_ad=$jac_ad"
@@ -145,7 +147,8 @@ function jac_config_ode(
             modeldata, 
             jac_solverview, # use all Variables in model
             jac_dispatchlists, # use only Reactions specified
-            jac_cache,
+            jac_cache;
+            throw_on_nan,
         )
 
         return jac, jac_prototype
@@ -177,6 +180,7 @@ function jac_config_dae(
     jac_cellranges=modeldata.cellranges_all,
     implicit_cellranges=modeldata.cellranges_all,
     generated_dispatch=true,
+    throw_on_nan=false,
     use_base_vars=String[],
 )
     @info "jac_config_dae: jac_ad=$jac_ad"
@@ -315,7 +319,8 @@ function jac_config_dae(
                 modeldata, 
                 jac_solverview, 
                 jac_dispatchlists,
-                jac_cache,
+                jac_cache;
+                throw_on_nan,
             ),
             odeimplicit
         )

--- a/src/SteadyState.jl
+++ b/src/SteadyState.jl
@@ -409,6 +409,10 @@ function solve_ptc(
     deltat = deltat_initial
     previous_state = copy(initial_state)
         
+    # record any initial state (eg state variables for short lived species)
+    initial_inner_state = get_state(ssFJ!) # so we can reset before writing output
+    inner_state = get_state(ssFJ!)
+
     ptc_iter = 1
     sol = nothing
     @time while tss < tss_max && ptc_iter <= max_iter
@@ -427,7 +431,7 @@ function solve_ptc(
         sol_ok = true
         try
             # solve nonlinear system for this pseudo-timestep
-            set_step!(ssFJ!, tss, deltat, previous_state)
+            set_step!(ssFJ!, tss, deltat, previous_state, inner_state)
             sol = NLsolve.nlsolve(nldf, previous_state; solvekwargs...)
             
             if verbose
@@ -470,9 +474,12 @@ function solve_ptc(
                 throw(e) # rethrow and fail
             end
         end
+       
+        if sol_ok
+            # record additional state (if any) from succesful step
+            get_state!(inner_state, ssFJ!)
 
-        # very crude pseudo-timestep adaptation (increase on success, reduce on failure)
-        if sol_ok          
+            # very crude pseudo-timestep adaptation (increase on success, reduce on failure)
             if deltat == deltat_full
                 # we used the full deltat and it worked - increase deltat
                 deltat *= deltat_fac
@@ -515,6 +522,8 @@ function solve_ptc(
 
     modelode = ssFJ!.modelode
     modeldata = modelode.modeldata
+    set_step!(ssFJ!, tss, 0.0, previous_state, initial_inner_state) # restore initial_inner_state
+    # NB: if using split dae with inner_state, this is updated in modeldata arrays as output is recalculated
     PALEOmodel.ODE.calc_output_sol!(outputwriter, run.model, tsoln, soln, modelode, modeldata)
     return nothing    
 end
@@ -544,15 +553,23 @@ struct FJacPTC
 end
 
 """
-    set_step!(fjp::FJacPTC, t, deltat, previous_u)
+    set_step!(fjp::FJacPTC, t, deltat, previous_u, state::Nothing)
 
 Set time to step to `t`, `delta_t` of this step, and `previous_u` (value of state vector at previous time step `t - delta_t`).
 """
-function set_step!(fjp::FJacPTC, t, deltat, previous_u)
+function set_step!(fjp::FJacPTC, t, deltat, previous_u, state::Nothing)
     fjp.t[] = t
     fjp.delta_t[] = deltat
     fjp.previous_u .= previous_u
 
+    return nothing
+end
+
+# no additional internal state
+function get_state!(state::Nothing, fjp::FJacPTC)
+end
+
+function get_state(fjp::FJacPTC)
     return nothing
 end
 
@@ -693,17 +710,40 @@ function Base.getproperty(obj::FJacSplitPTC, sym::Symbol)
 end
 
 """
-    set_step!(fjp::FJacSplitPTC, t, deltat, previous_u)
+    set_step!(fjp::FJacSplitPTC, t, deltat, previous_u, state)
 
-Set time to step to `t`, `delta_t` of this step, and `previous_u` (value of state vector at previous time step `t - delta_t`).
+Set time to step to `t`, `delta_t` of this step, `previous_u` (value of outer state vector at previous time step `t - delta_t`),
+and inner state variables (corresponding to algebraic constraints) in modeldata arrays to `state`.
 """
-function set_step!(fjp::FJacSplitPTC, t, deltat, previous_u)
+function set_step!(fjp::FJacSplitPTC, t, deltat, previous_u, state)
     fjp.t[] = t
     fjp.delta_t[] = deltat
     fjp.previous_u .= previous_u
+    # set inner state Variables from last timestep
+    copyto!(fjp.modeljacode.solver_view_all.state, state)
 
     return nothing
 end
+
+"""
+    get_state!(state, fjp::FJacSplitPTC)
+    get_state(fjp::FJacSplitPTC) -> state
+
+Record values for inner state variables from modeldata arrays to `state`
+"""
+function get_state!(state, fjp::FJacSplitPTC)
+    # record inner state Variables from successful timestep
+    copyto!(state, fjp.modeljacode.solver_view_all.state)
+    return nothing
+end
+
+function get_state(fjp::FJacSplitPTC)
+    state = similar(fjp.modeljacode.solver_view_all.state)
+    get_state!(state, fjp)
+    return state
+end
+
+
 
 # F only
 function (jn::FJacSplitPTC)(F::AbstractVector, u::AbstractVector)
@@ -754,7 +794,7 @@ function nlsolveF_SplitPTC(ms::SplitDAE.ModelSplitDAE, initial_state_outer, jaco
     deltat = Ref(NaN)
     previous_u = similar(initial_state_outer)
     du_worksp = similar(initial_state_outer)
- 
+
     # SplitDAE.ModelSplitDAE provides both ODE and Jacobian functions
     ssFJ! = FJacSplitPTC(ms, tss, deltat, previous_u, du_worksp)
 

--- a/src/SteadyState.jl
+++ b/src/SteadyState.jl
@@ -738,9 +738,7 @@ function get_state!(state, fjp::FJacSplitPTC)
 end
 
 function get_state(fjp::FJacSplitPTC)
-    state = similar(fjp.modeljacode.solver_view_all.state)
-    get_state!(state, fjp)
-    return state
+    return  PB.get_data(fjp.modeljacode.solver_view_all.state)
 end
 
 


### PR DESCRIPTION
Fixes failures due to a failed Newton step leaving inner state variables invalid (eg NaN), which then caused rare unrecoverable solver failure with reaction networks where the inner state variables have photochemical cross sections.

Keep track of 'internal' state (state variables corresponding to the 'inner' Newton solver for algebraic constraints), updating (only) on accepted pseudo-timesteps.

The ModelSplitDAE solver calculates the full derivative using current values of inner state variables (usually from the previous timestep), before the Newton solution  for the inner state variables. So these current values for the inner state variables need to be valid, for cases where those inner state variables affect the overall solution (eg have a photochemical cross section which affects the radiation field).
