### PR TITLE
Fixes to avoid spurious recompilation when using steady-state solvers

### DIFF
--- a/docs/src/PALEOmodelSolvers.md
+++ b/docs/src/PALEOmodelSolvers.md
@@ -50,6 +50,16 @@ steadystate_ptc
 steadystate_ptc_splitdae
 ```
 
+Function objects to project Newton steps into valid regions:
+
+```@meta
+CurrentModule = PALEOmodel.SolverFunctions
+```
+```@docs
+ClampAll!
+ClampAll
+```
+
 ## Steady-state solvers (Sundials Kinsol based):
 ```@meta
 CurrentModule = PALEOmodel.SteadyStateKinsol

--- a/src/NonLinearNewton.jl
+++ b/src/NonLinearNewton.jl
@@ -33,11 +33,11 @@ function solve(
     maxiters::Integer=100,
     verbose::Integer=0,
     jac_constant::Bool=false,
-    project_region = x->x,
+    project_region = identity,
 ) where {F, J}
 
     u = copy(u0)
-    residual = func(u0)
+    residual = func(u)
     Lnorm_2 = LinearAlgebra.norm(residual, 2)
     Lnorm_inf = LinearAlgebra.norm(residual, Inf)
     iters = 0

--- a/src/SolverFunctions.jl
+++ b/src/SolverFunctions.jl
@@ -17,6 +17,34 @@ import SparseDiffTools
 # import Infiltrator # Julia debugger
 
 """
+    ca! = ClampAll!(minvalue, maxvalue)
+    ca!(v)
+
+Function object to clamp all values in Vector `v` to specified range using
+`clamp!(v, minvalue, maxvalue)` (in-place, mutating version)
+"""
+struct ClampAll!
+    minvalue::Float64
+    maxvalue::Float64
+end
+
+(ca::ClampAll!)(v) = clamp!(v, ca.minvalue, ca.maxvalue)
+
+"""
+    ca = ClampAll(minvalue, maxvalue)
+    ca(v) -> v
+
+Function object to clamp all values in Vector `v` to specified range using
+`clamp.(v, minvalue, maxvalue)` (out-of-place version)
+"""
+struct ClampAll
+    minvalue::Float64
+    maxvalue::Float64
+end
+
+(ca::ClampAll)(v) = clamp.(v, ca.minvalue, ca.maxvalue)
+
+"""
     ModelODE(
         modeldata; 
         solver_view=modeldata.solver_view_all,


### PR DESCRIPTION
Fixes to avoid spurious recompilations when using  `PALEOmodel.SteadyState.steadystate_ptc`, `PALEOmodel.SteadyState.steadystate_ptc_splitdae`:

- don't specialize on solver keyword arguments

- provide function objects `SolverFunctions.ClampAll` `SolverFunctions.ClampAll!` to provide fixed types for `project_region` and `project_region!`, instead of eg supplying a function `project_region! = x->clamp!(x, 1e-80, 1.0)` in a script, which generates a new function each time the script is called and forces recompilation.