### PR TITLE
Speed up netcdf output by factor x2 - x3

### DIFF
--- a/src/OutputWriters.jl
+++ b/src/OutputWriters.jl
@@ -812,8 +812,8 @@ function save_netcdf(
     # Fails with variables with missing values eg that are  Union{Missing, Float64}
     # appears to be a NCDatasets.jl limitation (at least in v0.12.17) - the logic to map these to netcdf is 
     # combined with that to write the data, and the alternate form with just the type fails
-    # define_all_first = false 
-    define_all_first = true
+    define_all_first = false 
+    # define_all_first = true
 
     @info "saving to $filename ..."
 


### PR DESCRIPTION
- When reading netcdf, looking up netcdf variables by name is slow, so do this once and store in a Dict

- Test code for speeding up netcdf write, currently disabled (see https://github.com/Alexander-Barth/NCDatasets.jl/issues/223):
  When writing netcdf, use two passes first to define variables and then to write data Apparently netcdf is very slow when 
  swapping between two modes used for define and write NB: this does use more memory when saving the file.
