### PR TITLE
Add PALEOmodel.SteadyState.ConservationCallback

### DIFF
--- a/docs/src/PALEOmodelSolvers.md
+++ b/docs/src/PALEOmodelSolvers.md
@@ -48,6 +48,7 @@ CurrentModule = PALEOmodel.SteadyState
 steadystate
 steadystate_ptc
 steadystate_ptc_splitdae
+ConservationCallback
 ```
 
 Function objects to project Newton steps into valid regions:


### PR DESCRIPTION
`PALEOmodel.SteadyState` `steadystate_ptc_splitdae` and `steadystate_ptc_splitdae` add a `step_callbacks` keyword argument with list of callbacks to call after each succesful timestep.

Add `PALEOmodel.SteadyState.ConservationCallback` for use with eg atmospheric chemistry models, to enforce budget conservation by modifying state variable so change in eg H content matches boundary fluxes:

    ConservationCallback(
        tmodel_start::Float64 # earliest model time to apply correction
        content_name::String # variable with a total of X
        flux_name::String  # variable with a corresponding boundary flux of X
        reservoir_total_name::String  # total for reservoir to apply correction to
        reservoir_statevar_name::String # state variable for reservoir to apply correction to
        reservoir_fac::Float64  # stoichiometric factor (1 / moles of quantity X per reservoir molecule)
    ) -> ccb

This provides a callback function with signature

    ccb(state, tmodel, deltat, model, modeldata)

that modifies `modeldata` arrays and `state` to enforce budget conservation.

# Example

    conservation_callback_H = Callbacks.ConservationCallback(
        tmodel_start=1e5,
        content_name="global.content_H_atmocean",
        flux_name="global.total_H",
        reservoir_total_name="atm.CH4_total", # "atm.H2_total",
        reservoir_statevar_name="atm.CH4_mr", # "atm.H2_mr",
        reservoir_fac=0.25 # 0.5, # H per reservoir molecule
    )

    then add to eg `steadystate_ptc_splitdae` with `step_callbacks` keyword argument:

        step_callbacks = [conservation_callback_H]