### PR TITLE
Bugfix for SolverFunctions.StepClampAll!

### DIFF
--- a/src/SolverFunctions.jl
+++ b/src/SolverFunctions.jl
@@ -60,7 +60,7 @@ end
 function (sca::StepClampAll!)(x, x_old, newton_step)
     for i in eachindex(x)
         x[i] = x_old[i] + newton_step[i]
-        x[i] = clamp(x[i], scma.minvalue, scma.maxvalue)
+        x[i] = clamp(x[i], sca.minvalue, sca.maxvalue)
     end
     return nothing
 end


### PR DESCRIPTION
Fix typo in SolverFunctions.StepClampAll! that caused immediate error (NB: StepClampMultAll! is usually preferred anyway)