### PR TITLE
Bugfix and simplification for netcdf output

### DIFF
--- a/docs/src/PALEOmodelOutput.md
+++ b/docs/src/PALEOmodelOutput.md
@@ -44,7 +44,7 @@ PB.has_variable(output::PALEOmodel.AbstractOutputWriter, varname::AbstractString
 
 #### Accessing output data
 ```@docs
-PALEOmodel.get_array(output::PALEOmodel.AbstractOutputWriter, varname::AbstractString; kwargs...)
+PALEOmodel.get_array(output::PALEOmodel.AbstractOutputWriter, varname::AbstractString, allselectargs::NamedTuple; kwargs...)
 PB.get_field(output::PALEOmodel.AbstractOutputWriter, varname::AbstractString)
 PB.get_data(output::PALEOmodel.AbstractOutputWriter, varname::AbstractString; records=nothing)
 PB.get_mesh(output::PALEOmodel.AbstractOutputWriter, domainname::AbstractString)

--- a/src/CoordsDims.jl
+++ b/src/CoordsDims.jl
@@ -12,6 +12,9 @@ These are generated from coordinate variables for use in output visualisation.
 
 N = 1: a cell-centre coordinate, size(values) = (ncells, )
 N = 2: a boundary coordinate, size(values) = (2, ncells)
+
+# Fields
+$(TYPEDFIELDS)
 """
 mutable struct FixedCoord{N}
     name::String


### PR DESCRIPTION
Fix for variable with Space=PB.CellSpace in a scalar Domain (with no grid): this is represented by FieldArray and in netcdf output as 2 dimensional: (cell x tmodel) size (1, nrecs) (previous code got this wrong and FieldArray and netcdf output dropped the cell dimension, see bolded text below)

NB: there are three ways of representing a single scalar value per record or timestep; the dimensions and representation used by FieldArray.values and the netcdf file are considered well defined for analyzing output, the internal storage in FieldArray.records is an implementation detail (chosen to optimise storage of long timeseries of scalar variables):

1) A scalar variable Space=PB.ScalarSpace:
    - always represented by FieldArray and stored in netcdf as 1 dimensional: (tmodel), size (nrecs,)
    - always stored internally by FieldRecord (and accessed by PB.get_data) as a Vector{Float64} (ie one value per record or timestep)
  

2) A CellSpace variable Space=PB.CellSpace in a scalar Domain (with no grid)
    - **represented by FieldArray and stored in netcdf as 2 dimensional: (cells, tmodel), size (1, nrecs,) (the bugfix here)**
    - stored internally by FieldRecord (and accessed by PB.get_data) as a Vector{Float64} (ie one value per record index or timestep)
  

3) A CellSpace variable Space=PB.CellSpace in a Domain with a grid with one cell:
    - represented by FieldArray and stored in netcdf as 2 dimensional: (cells, tmodel), size (1, nrecs,)
    - stored internally by FieldRecord (and accessed by PB.get_data) as a Vector{Vector{Float64}}
      eg [[42.0], [43.0]]  (ie one value per record index or timestep, each value as a Vector{Float64} of length 1)
  

