### PR TITLE
Output datatype fix

### DIFF
--- a/src/FieldRecord.jl
+++ b/src/FieldRecord.jl
@@ -245,10 +245,10 @@ function PB.get_data(fr::FieldRecord; records=nothing)
         # if isa(records, Integer) && !isa(data_output, AbstractVector)
         #     data_output =[data_output]
         # 
-        if isa(records, Integer) && field_single_element(fr)            
-            # represent a scalar as a 0D Array
-            data_output = Array{eltype(fr.records), 0}(undef)
-            data_output[] = fr.records[records]
+        if isa(records, Integer) && field_single_element(fr)
+            # represent a scalar as a length 1 Vector
+            # (a 0D Array might be more logical, but for backwards compatibility keep as a Vector)
+            data_output =[fr.records[records]]
         else
             data_output = fr.records[records]
         end

--- a/src/Initialize.jl
+++ b/src/Initialize.jl
@@ -134,8 +134,11 @@ function set_statevar_from_output!(modeldata, output::AbstractOutputWriter)
             @info "  initialising Variable $domname.$varname from output record $pickup_record"
             vardata = PB.get_data(statevar, modeldata)
             pickup_data = PB.get_data(output, domname*"."*varname, records=pickup_record)
-            typeof(vardata) == typeof(pickup_data) ||
-                error("output Variable $domname.$varname has different type $(typeof(vardata)) != $(typeof(pickup_data))")
+            if typeof(vardata) != typeof(pickup_data)
+                # warn and continue - will fail later if broadcast doesn't work
+                @warn "output Variable $domname.$varname (type $(typeof(vardata)) size $(size(vardata)), length $(length(vardata)))"*
+                    " has different type to pickup data (type $(typeof(pickup_data)) size $(size(pickup_data)) length ($(length(pickup_data))))"
+            end
             vardata .= pickup_data
         else
             @info "  Variable $domname.$varname not present in output - leaving default initialisation"

--- a/src/OutputWriters.jl
+++ b/src/OutputWriters.jl
@@ -656,8 +656,7 @@ Save to `filename` in JLD2 format (NB: filename must either have no extension or
 """
 function save_jld2(output::OutputMemory, filename)
 
-    @error """save_jld2 has been removed in PALEOmodel v0.16
-              Please use save_netcdf instead"""
+    error("save_jld2 has been removed in PALEOmodel v0.16 - please use save_netcdf instead")
 
     return nothing
 end
@@ -673,9 +672,11 @@ Load from `filename` in JLD2 format, replacing any existing content in `output`.
 """
 function load_jld2!(output::OutputMemory, filename)
 
-   @error """load_jld2! has been removed in PALEOmodel v0.16.
-             Please use save_netcdf, load_netcdf! for new output,
-             or use an earlier version of PALEOmodel to load jld2 output and save to netcdf."""
+   error(
+    """load_jld2! has been removed in PALEOmodel v0.16.
+    Please use save_netcdf, load_netcdf! for new output,
+    or use an earlier version of PALEOmodel to load jld2 output and save to netcdf."""
+   )
 
     return nothing
 end

--- a/test/runoutputwritertests.jl
+++ b/test/runoutputwritertests.jl
@@ -38,6 +38,14 @@ end
     all_values.global.O .= [4e19]
     PALEOmodel.OutputWriters.add_record!(output, model, modeldata, 1.0)
 
+    O_data = PB.get_data(output, "global.O")
+    @test O_data isa Vector{Float64}
+    @test O_data == [2e19, 4e19]
+
+    O_data_rec2 = PB.get_data(output, "global.O"; records=2)
+    @test O_data_rec2 isa Vector{Float64}  # Vector, not a 0D Array !
+    @test O_data_rec2 == [4e19]
+
     O_array = PALEOmodel.get_array(output, "global.O")
     @test O_array.values == [2e19, 4e19]
 
@@ -60,25 +68,22 @@ end
 
 end
 
-# @testset "SaveLoad_jld2" begin
+@testset "SaveLoad_jld2" begin
 
-#     model, modeldata, all_vars, output =  create_test_model_output(2)
-#     all_values = all_vars.values
+    model, modeldata, all_vars, output =  create_test_model_output(2)
+    all_values = all_vars.values
 
-#     all_values.global.O .= [2e19]
-#     PALEOmodel.OutputWriters.add_record!(output, model, modeldata, 0.0)
-#     all_values.global.O .= [4e19]
-#     PALEOmodel.OutputWriters.add_record!(output, model, modeldata, 0.0)
+    all_values.global.O .= [2e19]
+    PALEOmodel.OutputWriters.add_record!(output, model, modeldata, 0.0)
+    all_values.global.O .= [4e19]
+    PALEOmodel.OutputWriters.add_record!(output, model, modeldata, 0.0)
 
-#     tmpfile = tempname(; cleanup=true) 
-#     PALEOmodel.OutputWriters.save_jld2(output, tmpfile)
+    tmpfile = tempname(; cleanup=true) 
+    @test_throws str->occursin("save_jld2 has been removed", str) PALEOmodel.OutputWriters.save_jld2(output, tmpfile)
 
-#     load_output = PALEOmodel.OutputWriters.load_jld2!(PALEOmodel.OutputWriters.OutputMemory(), tmpfile)
+    @test_throws str->occursin("load_jld2! has been removed", str)  PALEOmodel.OutputWriters.load_jld2!(PALEOmodel.OutputWriters.OutputMemory(), tmpfile)
 
-#     O_array = PALEOmodel.get_array(load_output, "global.O")
-#     @test O_array.values == [2e19, 4e19]
-
-# end
+end
 
 @testset "SaveLoad_netcdf" begin
 


### PR DESCRIPTION
Bugfix: get_data(output) with a single value
Backwards compatibility fix:

    PB.get_data(output, "some_scalar_variable"; records=3) -> Vector

(scalar variable with a single record) returns a Vector length 1, not a 0D Array