### PR TITLE
Simplify coordinates: replace FixedCoord with FieldArray

### DIFF
--- a/docs/src/PALEOmodelOutput.md
+++ b/docs/src/PALEOmodelOutput.md
@@ -76,12 +76,11 @@ load_netcdf!
 ```@meta
 CurrentModule = PALEOmodel
 ```
-[`FieldArray`](@ref) provides a generic array type with named dimensions `PALEOboxes.NamedDimension` and optional coordinates [`PALEOmodel.FixedCoord`](@ref) for processing of model output.
+[`FieldArray`](@ref) provides a generic array type with named dimensions `PALEOboxes.NamedDimension` each with optional coordinates for processing of model output.
 
 ```@docs
 FieldArray
 get_array(fr::FieldRecord)
-FixedCoord
 ```
 
 ## Plotting output

--- a/src/FieldArray.jl
+++ b/src/FieldArray.jl
@@ -17,35 +17,38 @@ struct FieldArray{T <: AbstractArray}
     "n-dimensional Array of values"
     values::T
     "Names of dimensions with optional attached coordinates"
-    dims_coords::Vector{Pair{PB.NamedDimension, Vector{FixedCoord}}}
+    dims_coords::Vector{Pair{PB.NamedDimension, Vector{FieldArray}}}
     "variable attributes"
     attributes::Union{Dict{Symbol, Any}, Nothing}
 end
 
+
 PB.get_dimensions(f::FieldArray) = PB.NamedDimension[first(dc) for dc in f.dims_coords]
 
 function Base.show(io::IO, fa::FieldArray)
+    get(io, :typeinfo, nothing) === FieldArray || print(io, "FieldArray")
     print(io, 
-        "FieldArray(name=\"", fa.name, "\", eltype=", eltype(fa.values), ", size=", size(fa.values), ", dims_coords=", fa.dims_coords, ")"
+        "(name=\"", fa.name, "\", eltype=", eltype(fa.values), ", size=", size(fa.values), ", dims_coords=["
     )
+    for (i, (nd, coords)) in enumerate(fa.dims_coords)
+        print(IOContext(io, :typeinfo=>PB.NamedDimension), nd)
+        isempty(coords) || print(io, " => ", [c.name for c in coords])
+        i == length(fa.dims_coords) || print(io, ", ")
+    end
+    print(io, "])")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", fa::FieldArray)
     println(io, "FieldArray(name=\"", fa.name, "\", eltype=", eltype(fa.values),  ", size=", size(fa.values), ")")
-    # println(io, "  dims_coords:")
-    # for (nd, coords) in fa.dims_coords
-    #     println(io, "    ", nd, " => ")
-    #     for c in coords
-    #         println(io, "        ", c)
-    #     end
-    # end
-
     println(io, "  dims_coords:")
     for (nd, coords) in fa.dims_coords
-        println(io, "    ", nd, " => ", [c.name for c in coords])
+        print(IOContext(io, :typeinfo=>PB.NamedDimension), "     ", nd)
+        isempty(coords) || print(io, " => ", [c.name for c in coords])
+        println()
     end
     println(io, "  attributes: ", fa.attributes)
 end
+
 
 # basic arithmetic operations
 function Base.:*(fa_in::FieldArray, a::Real)

--- a/src/OutputWriters.jl
+++ b/src/OutputWriters.jl
@@ -931,10 +931,6 @@ function save_netcdf(
             grid_to_netcdf!(dsg, odom.grid)
 
             # data_dims
-            # TODO these are NamedDimension with attached FixedCoord, where
-            # the FixedCoord may not be present as a variable in the data,
-            # and may also not have the correct name or even a unique name !
-            # As a workaround, we generate a unique name from dim_name * coord_name, and add the Variable
             data_dim_names = String[d.name for d in odom.data_dims]
             dsg.attrib["data_dims"] = data_dim_names
             coordnames_to_netcdf(dsg, "data_dims_coords", odom.data_dims_coordinates)            

--- a/src/PALEOmodel.jl
+++ b/src/PALEOmodel.jl
@@ -63,9 +63,9 @@ include("SteadyState.jl")
 
 include("SteadyStateKinsol.jl")
 
-include("CoordsDims.jl") 
-
 include("FieldArray.jl")
+
+include("CoordsDims.jl") 
 
 include("FieldRecord.jl")
 

--- a/src/PlotRecipes.jl
+++ b/src/PlotRecipes.jl
@@ -485,7 +485,7 @@ end
 #########################################################
 
 """
-    build_coords_edges(coords_vec::Vector{FixedCoord}) -> Vector{Float64}
+    build_coords_edges(coords_vec::Vector{FieldArray}) -> Vector{Float64}
 
 Build a vector of coordinate edges (length `n+1``) from `coords_vec`, assuming the PALEO
 convention that `coords_vec` contains three elements with 
@@ -493,7 +493,7 @@ cell midpoints, lower edges, upper edges each of length `n`, in that order.
 
 Falls back to just returning the first entry in `coords_vec` for other cases.
 """
-function build_coords_edges(dim::PB.NamedDimension, coords_vec::Vector{FixedCoord})
+function build_coords_edges(dim::PB.NamedDimension, coords_vec::Vector{FieldArray})
 
     if isempty(coords_vec)
         # no coordinate - just return indices


### PR DESCRIPTION
This simplifies the way coordinates are represented in FieldArray output.

FieldArray coordinates are now themselves FieldArrays (with named dimensions, but without any attached coordinates), FixedCoord struct is now removed.

This should also be more robust and transparent as coordinates are now handled the same way as any other PALEO variable.