### PR TITLE
Define and test behaviour of get_data

### DIFF
--- a/docs/src/PALEOmodelOutput.md
+++ b/docs/src/PALEOmodelOutput.md
@@ -47,6 +47,7 @@ PB.has_variable(output::PALEOmodel.AbstractOutputWriter, varname::AbstractString
 PALEOmodel.get_array(output::PALEOmodel.AbstractOutputWriter, varname::AbstractString, allselectargs::NamedTuple; kwargs...)
 PB.get_field(output::PALEOmodel.AbstractOutputWriter, varname::AbstractString)
 PB.get_data(output::PALEOmodel.AbstractOutputWriter, varname::AbstractString; records=nothing)
+PB.get_data(fr::PALEOmodel.FieldRecord; records=nothing)
 PB.get_mesh(output::PALEOmodel.AbstractOutputWriter, domainname::AbstractString)
 ```
 ```@meta

--- a/test/runoutputwritertests.jl
+++ b/test/runoutputwritertests.jl
@@ -164,7 +164,7 @@ end
     # add a diagnostic
     fr_O = PB.get_field(output, "global.O")
     my_diag = copy(fr_O)
-    my_diag.records .= -42.0
+    my_diag.records .= -42.0 # TODO directly accessing records is only valid for scalar data
     my_diag.attributes[:var_name] = "my_diag"
     my_diag.attributes[:description] = "a model diagnostic calculated from global.O"
     PB.add_field!(diag, my_diag)


### PR DESCRIPTION
Change in behaviour (really a bugfix) for get_data for a CellSpace variable in a Domain with one cell: now returns a Vector ie spatial dimension is squeezed out (previously, returned a Vector-of-length-1-Vectors)

    PB.get_data(fr::FieldRecord; records=nothing, squeeze_all_single_dims=true)

Get data records in raw format. Only recommended for variables with scalar data ie one value per record.

`records` may be `nothing` to get all records,
an `Int` to select a single record, or a range to select multiple records.

If `squeeze_all_single_dims=true` (the default), if each record represents a scalar (eg a PALEO Variable with Space PB.ScalarSpace, or a PB.CellSpace variable in a Domain with a single cell), then data is returned as a Vector. NB: if `records` is an Int, the single record requested is returned as a length-1 Vector.

Non-scalar data (eg a non-ScalarSpace variable from a Domain with > 1 cell) is returned in internal format as a Vector-of-Vectors.