### PR TITLE
Add public keyword for Julia 1.11

### DIFF
--- a/src/JacobianAD.jl
+++ b/src/JacobianAD.jl
@@ -2,7 +2,8 @@ module JacobianAD
 
 import PALEOboxes as PB
 
-import PALEOmodel
+import ...PALEOmodel
+using ...PALEOmodel: @public
 import ..SolverFunctions
 import ..SparseUtils
 
@@ -17,6 +18,8 @@ import SparseDiffTools
 import SparsityTracing
 
 import TimerOutputs: @timeit, @timeit_debug
+
+@public jac_config_ode, paramjac_config_ode, jac_config_dae
 
 # moved to SolverFunctions
 # Base.@deprecate_binding DerivForwardDiff  SolverFunctions.DerivForwardDiff

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -2,7 +2,9 @@ module ODE
 
 import PALEOboxes as PB
 
-import PALEOmodel
+import ...PALEOmodel
+using ...PALEOmodel: @public
+
 import ..SolverFunctions
 
 import LinearAlgebra
@@ -22,6 +24,9 @@ import Infiltrator
 import Sundials
 import SciMLBase
 
+@public ODEfunction, DAEfunction
+@public integrate, integrateForwardDiff, integrateDAE, integrateDAEForwardDiff, get_inconsistent_initial_deriv
+@public print_sol_stats, calc_output_sol!
 
 Base.@deprecate_binding ModelODE SolverFunctions.ModelODE
 # Base.@deprecate_binding ModelDAE SolverFunctions.ModelDAE

--- a/src/ODELocalIMEX.jl
+++ b/src/ODELocalIMEX.jl
@@ -4,13 +4,16 @@ import Infiltrator
 
 import PALEOboxes as PB
 
-import PALEOmodel
+import ...PALEOmodel
+using ...PALEOmodel: @public
 import ..NonLinearNewton
 
 import Logging
 import LinearAlgebra
 import ForwardDiff
 import StaticArrays
+
+@public integrateLocalIMEXEuler
 
 """
     integrateLocalIMEXEuler(run, initial_state, modeldata, tspan, Δt_outer [; kwargs...])

--- a/src/ODEfixed.jl
+++ b/src/ODEfixed.jl
@@ -4,8 +4,10 @@ module ODEfixed
 
 import PALEOboxes as PB
 
-import PALEOmodel
+import ...PALEOmodel
+using ...PALEOmodel: @public
 
+@public integrateEuler, integrateSplitEuler, integrateEulerthreads, integrateSplitEulerthreads
 
 ###########################################################################
 # Fixed-timestep, first-order Euler integrators 

--- a/src/OutputWriters.jl
+++ b/src/OutputWriters.jl
@@ -7,15 +7,15 @@ module OutputWriters
 
 import PALEOboxes as PB
 
-import PALEOmodel
+import ...PALEOmodel
+using ...PALEOmodel: @public
 
 import OrderedCollections
 import DataFrames
 import FileIO
 import NCDatasets
 
-import Infiltrator # Julia debugger
-
+@public initialize!, add_record!, OutputMemoryDomain, OutputMemory, save_netcdf, load_netcdf!
 
 ##################################
 # AbstractOutputWriter interface
@@ -51,8 +51,8 @@ PALEOmodel.AbstractOutputWriter
 
 """
     initialize!(
-        output::PALEOmodel.AbstractOutputWriter, model, modeldata, [nrecords] 
-        [;record_dim_name=:tmodel] [record_coord_units="yr"]
+        output::PALEOmodel.AbstractOutputWriter, model, modeldata, [nrecords]; 
+        [record_dim_name=:tmodel] [record_coord_name=record_dim_name] [record_coord_units="yr"]
     )
 
 Initialize from a PALEOboxes::Model, optionally reserving memory for an assumed output dataset of `nrecords`.

--- a/src/PALEOmodel.jl
+++ b/src/PALEOmodel.jl
@@ -26,12 +26,32 @@ using DocStringExtensions
 
 import TimerOutputs: @timeit, @timeit_debug
 
+# https://discourse.julialang.org/t/is-compat-jl-worth-it-for-the-public-keyword/119041/22
+# define @public for backwards compatibility with Julia < v1.11
+macro public(ex)
+    if VERSION >= v"1.11"
+        args = ex isa Symbol ? (ex,) : Base.isexpr(ex, :tuple) ? ex.args : error("@public parse error")
+        esc(Expr(:public, args...))
+    else
+        nothing
+    end
+end
+
+@public Run, initialize!, set_statevar_from_output!
+@public SolverView, set_default_solver_view!, copy_norm!, set_statevar!, set_tforce, get_statevar!, get_statevar_sms!
+@public SolverFunctions, JacobianAD, ODE, ThreadBarriers, ODEfixed, ODELocalIMEX, SteadyState, SteadyStateKinsol
+@public AbstractOutputWriter, OutputWriters, FieldRecord, FieldArray, get_array
+@public PlotPager
+@public ReactionNetwork
+
+
 # Get scalar value from variable x (discarding any AD derivatives)
 PB.value_ad(x::SparsityTracing.ADval) = SparsityTracing.value(x)
 PB.value_ad(x::ForwardDiff.Dual) = ForwardDiff.value(x)
 
 abstract type AbstractOutputWriter
 end
+
 
 include("SparseUtils.jl")
 

--- a/src/PlotRecipes.jl
+++ b/src/PlotRecipes.jl
@@ -1,5 +1,4 @@
 import RecipesBase
-import Infiltrator
 
 ###########################
 # PlotPager

--- a/src/ReactionNetwork.jl
+++ b/src/ReactionNetwork.jl
@@ -15,8 +15,11 @@ module ReactionNetwork
 import Printf
 import Requires
 import PALEOboxes as PB
-import PALEOmodel
+import ...PALEOmodel
+using ...PALEOmodel: @public
 import DataFrames
+
+@public get_ratetable, get_all_species_ratevars, get_rates, get_all_species_ratesummaries, show_ratesummaries
 
 """
     add_equations!(ratetable)

--- a/src/SolverFunctions.jl
+++ b/src/SolverFunctions.jl
@@ -7,7 +7,8 @@ module SolverFunctions
 
 import PALEOboxes as PB
 
-import PALEOmodel
+import ...PALEOmodel
+using ...PALEOmodel: @public
 
 import LinearAlgebra
 import SparseArrays
@@ -16,7 +17,11 @@ import SparseDiffTools
 import MultiFloats
 import Sparspak
 
-# import Infiltrator # Julia debugger
+@public StepClampMultAll!, StepClampAll!, ClampAll, ClampAll!, SparseLinsolveUMFPACK, SparseLinsolveSparspak64x2
+@public ModelODE, ModelODE_at_t, ModelODE_p_at_t, ModelODE_u_at_t
+@public JacODEForwardDiffDense, JacODEForwardDiffDense_p, JacODEForwardDiffSparse, JacODE_at_t
+@public ParamJacODEForwardDiffDense, ParamJacODEForwardDiffDenseT
+@public ModelDAE, JacDAE, TotalForwardDiff, ImplicitForwardDiffDense, ImplicitForwardDiffSparse
 
 #####################################################################################
 # Adaptors and function objects for NLsolve (non-linear steady-state solvers)
@@ -84,7 +89,7 @@ end
 (ca::ClampAll!)(v) = clamp!(v, ca.minvalue, ca.maxvalue)
 
 """
-    ca = ClampAll(minvalue, maxvalue)
+    ClampAll(minvalue, maxvalue) -> ca
     ca(v) -> v
 
 Function object to clamp all values in Vector `v` to specified range using

--- a/src/SparseUtils.jl
+++ b/src/SparseUtils.jl
@@ -7,7 +7,6 @@ module SparseUtils
 
 import SparseArrays
 import LinearAlgebra
-import Infiltrator
 
 """
     add_sparse_fixed!(A::SparseMatrixCSC, B::SparseMatrixCSC)

--- a/src/SplitDAE.jl
+++ b/src/SplitDAE.jl
@@ -2,7 +2,7 @@ module SplitDAE
 
 import PALEOboxes as PB
 
-import PALEOmodel
+import ...PALEOmodel
 
 import LinearAlgebra
 import SparseArrays

--- a/src/SteadyState.jl
+++ b/src/SteadyState.jl
@@ -2,7 +2,8 @@ module SteadyState
 
 import PALEOboxes as PB
 
-import PALEOmodel
+import ...PALEOmodel
+using ...PALEOmodel: @public
 
 import LinearAlgebra
 import SparseArrays
@@ -15,6 +16,9 @@ import ..JacobianAD
 import ..SplitDAE
 
 import TimerOutputs: @timeit, @timeit_debug
+
+@public steadystate, steadystateForwardDiff, steadystate_ptc, steadystate_ptcForwardDiff, steadystate_ptc_splitdae
+@public ConservationCallback, RestartSmallValuesCallback, CheckValuesCallback
 
 ##############################################################
 # Solve for steady state using NLsolve.jl

--- a/src/SteadyStateKinsol.jl
+++ b/src/SteadyStateKinsol.jl
@@ -2,7 +2,8 @@ module SteadyStateKinsol
 
 import PALEOboxes as PB
 
-import PALEOmodel
+import ...PALEOmodel
+using ...PALEOmodel: @public
 
 import Sundials
 using LinearAlgebra
@@ -12,6 +13,7 @@ using ForwardDiff
 using SparseArrays
 using SparseDiffTools
 
+@public steadystate_ptc
 
 """
     steadystate_ptc(run, initial_state, modeldata, tspan, deltat_initial; 

--- a/src/ThreadBarriers.jl
+++ b/src/ThreadBarriers.jl
@@ -5,6 +5,9 @@
 """
 module ThreadBarriers
 
+using ...PALEOmodel: @public
+
+@public ThreadBarrierAtomic
 
 """
     wait_barrier(barrier::Nothing)


### PR DESCRIPTION
Use @public macro from https://discourse.julialang.org/t/is-compat-jl-worth-it-for-the-public-keyword/119041/22 to maintain backwards compatibility with earlier Julia versions.